### PR TITLE
feat: add functionality to remove profile picture in account settings

### DIFF
--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -23,6 +23,7 @@ import UIWindowChangeUsername from '../UIWindowChangeUsername.js';
 import UIWindowConfirmUserDeletion from './UIWindowConfirmUserDeletion.js';
 import UIWindowManageSessions from '../UIWindowManageSessions.js';
 import UIWindow from '../UIWindow.js';
+import UIAlert from '../UIAlert.js';
 
 // About
 export default {
@@ -157,19 +158,67 @@ export default {
         })
 
         $el_window.find('.remove-profile-picture').on('click', async function (e) {
-            // Remove profile picture by setting it to null/undefined
-            const defaultIcon = window.icons['profile.svg'];
+            // Show confirmation dialog
+            const confirmed = await UIAlert({
+                message: i18n('confirm_remove_profile_picture') || 'Are you sure you want to remove your profile picture?',
+                buttons: [
+                    {
+                        label: i18n('cancel') || 'Cancel',
+                        value: false,
+                        type: 'default'
+                    },
+                    {
+                        label: i18n('remove') || 'Remove',
+                        value: true,
+                        type: 'primary'
+                    }
+                ],
+                parent_uuid: $el_window.attr('data-element_uuid')
+            });
 
-            // Update UI
-            $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
-            $('.profile-image').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
-            $('.profile-image').removeClass('profile-image-has-picture');
+            if (!confirmed || confirmed === 'false') {
+                return;
+            }
 
-            // Update profile to remove picture
-            update_profile(window.user.username, {picture: null});
+            const $removeBtn = $(this);
+            const originalText = $removeBtn.text();
 
-            // Hide the remove button since there's no picture anymore
-            $(this).hide();
+            try {
+                // Show loading state
+                $removeBtn.prop('disabled', true).text(i18n('removing') || 'Removing...');
+
+                const defaultIcon = window.icons['profile.svg'];
+
+                // Update UI
+                $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
+                $('.profile-image').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
+                $('.profile-image').removeClass('profile-image-has-picture');
+
+                // Update profile to remove picture
+                await update_profile(window.user.username, {picture: null});
+
+                // Hide the remove button since there's no picture anymore
+                $removeBtn.hide();
+
+                // Show success message
+                await UIAlert({
+                    message: i18n('profile_picture_removed') || 'Profile picture removed successfully.',
+                    type: 'success',
+                    parent_uuid: $el_window.attr('data-element_uuid')
+                });
+
+            } catch (error) {
+                // Restore button state on error
+                $removeBtn.prop('disabled', false).text(originalText);
+
+                // Show error message
+                await UIAlert({
+                    message: i18n('error_removing_profile_picture') || 'An error occurred while removing your profile picture. Please try again.',
+                    parent_uuid: $el_window.attr('data-element_uuid')
+                });
+
+                console.error('Error removing profile picture:', error);
+            }
         })
 
         $el_window.on('file_opened', async function(e){
@@ -204,12 +253,67 @@ export default {
 
                         // Attach click handler to the new button
                         $el_window.find('.remove-profile-picture').on('click', async function (e) {
-                            const defaultIcon = window.icons['profile.svg'];
-                            $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
-                            $('.profile-image').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
-                            $('.profile-image').removeClass('profile-image-has-picture');
-                            update_profile(window.user.username, {picture: null});
-                            $(this).hide();
+                            // Show confirmation dialog
+                            const confirmed = await UIAlert({
+                                message: i18n('confirm_remove_profile_picture') || 'Are you sure you want to remove your profile picture?',
+                                buttons: [
+                                    {
+                                        label: i18n('cancel') || 'Cancel',
+                                        value: false,
+                                        type: 'default'
+                                    },
+                                    {
+                                        label: i18n('remove') || 'Remove',
+                                        value: true,
+                                        type: 'primary'
+                                    }
+                                ],
+                                parent_uuid: $el_window.attr('data-element_uuid')
+                            });
+
+                            if (!confirmed || confirmed === 'false') {
+                                return;
+                            }
+
+                            const $removeBtn = $(this);
+                            const originalText = $removeBtn.text();
+
+                            try {
+                                // Show loading state
+                                $removeBtn.prop('disabled', true).text(i18n('removing') || 'Removing...');
+
+                                const defaultIcon = window.icons['profile.svg'];
+
+                                // Update UI
+                                $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
+                                $('.profile-image').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
+                                $('.profile-image').removeClass('profile-image-has-picture');
+
+                                // Update profile to remove picture
+                                await update_profile(window.user.username, {picture: null});
+
+                                // Hide the remove button since there's no picture anymore
+                                $removeBtn.hide();
+
+                                // Show success message
+                                await UIAlert({
+                                    message: i18n('profile_picture_removed') || 'Profile picture removed successfully.',
+                                    type: 'success',
+                                    parent_uuid: $el_window.attr('data-element_uuid')
+                                });
+
+                            } catch (error) {
+                                // Restore button state on error
+                                $removeBtn.prop('disabled', false).text(originalText);
+
+                                // Show error message
+                                await UIAlert({
+                                    message: i18n('error_removing_profile_picture') || 'An error occurred while removing your profile picture. Please try again.',
+                                    parent_uuid: $el_window.attr('data-element_uuid')
+                                });
+
+                                console.error('Error removing profile picture:', error);
+                            }
                         })
                     } else {
                         $el_window.find('.remove-profile-picture').show();

--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -37,6 +37,12 @@ export default {
         h += `<div style="overflow: hidden; display: flex; margin-bottom: 20px; flex-direction: column; align-items: center;">`;
             h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
             h += `</div>`;
+            h += `<div style="margin-top: 10px; display: flex; gap: 10px;">`;
+                h += `<button class="button change-profile-picture-btn">${i18n('change_profile_picture') || 'Change'}</button>`;
+                if(window.user?.profile?.picture){
+                    h += `<button class="button button-danger remove-profile-picture">${i18n('remove_profile_picture') || 'Remove'}</button>`;
+                }
+            h += `</div>`;
         h += `</div>`;
 
         // change password button
@@ -134,7 +140,7 @@ export default {
             });
         });
 
-        $el_window.find('.change-profile-picture').on('click', async function (e) {
+        $el_window.find('.change-profile-picture, .change-profile-picture-btn').on('click', async function (e) {
             // open dialog
             UIWindow({
                 path: '/' + window.user.username + '/Desktop',
@@ -147,7 +153,23 @@ export default {
                 is_dir: true,
                 is_openFileDialog: true,
                 selectable_body: false,
-            });    
+            });
+        })
+
+        $el_window.find('.remove-profile-picture').on('click', async function (e) {
+            // Remove profile picture by setting it to null/undefined
+            const defaultIcon = window.icons['profile.svg'];
+
+            // Update UI
+            $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
+            $('.profile-image').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
+            $('.profile-image').removeClass('profile-image-has-picture');
+
+            // Update profile to remove picture
+            update_profile(window.user.username, {picture: null});
+
+            // Hide the remove button since there's no picture anymore
+            $(this).hide();
         })
 
         $el_window.on('file_opened', async function(e){
@@ -174,6 +196,24 @@ export default {
                     $('.profile-image').addClass('profile-image-has-picture');
                     // update profile picture
                     update_profile(window.user.username, {picture: base64data})
+
+                    // Show remove button if it doesn't exist, or make it visible if it does
+                    if($el_window.find('.remove-profile-picture').length === 0){
+                        const removeBtn = `<button class="button button-danger remove-profile-picture">${i18n('remove_profile_picture') || 'Remove'}</button>`;
+                        $el_window.find('.change-profile-picture-btn').parent().append(removeBtn);
+
+                        // Attach click handler to the new button
+                        $el_window.find('.remove-profile-picture').on('click', async function (e) {
+                            const defaultIcon = window.icons['profile.svg'];
+                            $el_window.find('.profile-picture').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
+                            $('.profile-image').css('background-image', 'url(' + html_encode(defaultIcon) + ')');
+                            $('.profile-image').removeClass('profile-image-has-picture');
+                            update_profile(window.user.username, {picture: null});
+                            $(this).hide();
+                        })
+                    } else {
+                        $el_window.find('.remove-profile-picture').show();
+                    }
                 }
             }
         })

--- a/src/gui/src/UI/Settings/UITabAccount.js
+++ b/src/gui/src/UI/Settings/UITabAccount.js
@@ -39,9 +39,9 @@ export default {
             h += `<div class="profile-picture change-profile-picture" style="background-image: url('${html_encode(window.user?.profile?.picture ?? window.icons['profile.svg'])}');">`;
             h += `</div>`;
             h += `<div style="margin-top: 10px; display: flex; gap: 10px;">`;
-                h += `<button class="button change-profile-picture-btn">${i18n('change_profile_picture') || 'Change'}</button>`;
+                h += `<button class="button change-profile-picture-btn" aria-label="${i18n('change_profile_picture') || 'Change profile picture'}">${i18n('change_profile_picture') || 'Change'}</button>`;
                 if(window.user?.profile?.picture){
-                    h += `<button class="button button-danger remove-profile-picture">${i18n('remove_profile_picture') || 'Remove'}</button>`;
+                    h += `<button class="button button-danger remove-profile-picture" aria-label="${i18n('remove_profile_picture') || 'Remove profile picture'}">${i18n('remove_profile_picture') || 'Remove'}</button>`;
                 }
             h += `</div>`;
         h += `</div>`;
@@ -248,7 +248,7 @@ export default {
 
                     // Show remove button if it doesn't exist, or make it visible if it does
                     if($el_window.find('.remove-profile-picture').length === 0){
-                        const removeBtn = `<button class="button button-danger remove-profile-picture">${i18n('remove_profile_picture') || 'Remove'}</button>`;
+                        const removeBtn = `<button class="button button-danger remove-profile-picture" aria-label="${i18n('remove_profile_picture') || 'Remove profile picture'}">${i18n('remove_profile_picture') || 'Remove'}</button>`;
                         $el_window.find('.change-profile-picture-btn').parent().append(removeBtn);
 
                         // Attach click handler to the new button


### PR DESCRIPTION
## Summary
Add "Remove Profile Picture" button to account settings, allowing users to delete their current profile picture and revert to the default avatar with confirmation dialog, error handling, and loading states.

## Related Issue
- Closes #5

## Type of Change
- ✨ **feat:** New features (first introduction of a feature)

## Changes Made
- Add "Change" and "Remove" buttons below the profile picture in account settings
- Implement remove profile picture functionality that resets to default avatar
- Add confirmation dialog before removing profile picture to prevent accidental deletion
- Implement comprehensive error handling with user-friendly error messages
- Add loading state with disabled button and "Removing..." text during operation
- Show success message after successful profile picture removal
- Add aria-label accessibility attributes to all buttons for screen reader support
- Update profile picture UI to conditionally show the "Remove" button only when a profile picture exists
- Add dynamic button visibility logic that shows/hides the remove button when pictures are uploaded or removed
- Ensure profile picture removal persists by updating the user's .profile file

## Testing
- [x] I have tested this change locally
- [x] I have verified no regressions in "appspace" (Puter apps)
- [x] I have tested on multiple browsers (if UI changes)
- [x] All existing functionality still works as expected

**Testing Details:**
Verified that:
- The "Change" button appears for all users
- The "Remove" button only appears when a profile picture is set
- Confirmation dialog appears when clicking "Remove"
- Button shows loading state ("Removing...") during operation
- Clicking "Remove" successfully reverts to the default avatar after confirmation
- Success message appears after successful removal
- Error handling works correctly with user-friendly error messages
- The remove button disappears after removing the profile picture
- Uploading a new profile picture shows the remove button again
- Profile picture changes persist across sessions via the .profile file update
- Screen readers can properly identify buttons via aria-labels

## Screenshots/Demo

<img width="1059" height="750" alt="image" src="https://github.com/user-attachments/assets/ee5c07ec-c6cc-4dd2-b6ce-ab1f1171f018" />
<img width="1025" height="704" alt="image" src="https://github.com/user-attachments/assets/669db067-ad79-4a6d-bdbd-f9d831d40493" />
<img width="960" height="653" alt="image" src="https://github.com/user-attachments/assets/e20edfdd-c64f-4027-8bdd-7e59328f257e" />
<img width="866" height="611" alt="image" src="https://github.com/user-attachments/assets/bf80ccff-17f3-4180-99d0-8464986329eb" />


https://github.com/user-attachments/assets/989c5233-3814-4513-81fe-2a5c297a95c9


## Code Quality Checklist
- [x] I have avoided unnecessary whitespace changes
- [x] I have followed the project-level conventions for the area I'm working in:
  - [x] Standard whitespace for `src/gui` (if applicable)
- [x] I have kept formatting changes separate from functional changes
- [x] I have used imperative mood in commit messages
- [x] My changes generate no new warnings or errors

## Puter-Specific Checks
- [x] **No regressions for "appspace"** - Existing Puter apps still work correctly
- [x] If this changes APIs, I have considered backward compatibility
- [x] If this affects the file system, I have tested file operations
- [x] If this affects user authentication, I have tested sign-in/sign-up flows

## Additional Context
This implementation uses the existing `update_profile()` helper function which stores profile data in the user's `/Public/.profile` file. Setting `picture: null` effectively removes the profile picture from the profile object, causing the UI to fall back to the default `profile.svg` icon.

The remove button uses the `button-danger` class to indicate a destructive action, consistent with other critical actions like "Delete Account" in the same settings panel.

### User Experience Enhancements
- **Confirmation Dialog**: Prevents accidental profile picture deletion
- **Loading States**: Provides visual feedback during async operations
- **Error Handling**: Gracefully handles failures and informs users
- **Success Feedback**: Confirms successful operations
- **Accessibility**: Full screen reader support via ARIA labels

### Technical Implementation
- Uses existing `UIAlert` component for consistent dialog styling
- Implements try-catch error handling for robust operation
- Maintains button state and restores it on errors
- Follows existing codebase patterns for HTML generation and event handling
- Properly integrated with i18n system for internationalization support