### PR TITLE
feat: add 'Set as Desktop Background' option for image files (issue #7)

### DIFF
--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -26,6 +26,7 @@ import UIWindowEmailConfirmationRequired from './UIWindowEmailConfirmationRequir
 import UIContextMenu from './UIContextMenu.js'
 import UIAlert from './UIAlert.js'
 import path from "../lib/path.js"
+import mime from "../lib/mime.js"
 import truncate_filename from '../helpers/truncate_filename.js';
 import launch_app from "../helpers/launch_app.js"
 import open_item from "../helpers/open_item.js"
@@ -1155,6 +1156,60 @@ function UIItem(options){
                 });
 
                 menu_items.push('-');
+            }
+
+            // -------------------------------------------
+            // Set as Desktop Background
+            // -------------------------------------------
+            // Check if this is an image file (not a folder, not in trash)
+            // Get the MIME type from options.type or detect from filename
+            const file_type = options.type || (options.name ? mime.getType(options.name) : null);
+            const is_image = !options.is_dir && file_type && file_type.startsWith('image/');
+            if(!is_trashed && !is_trash && is_image){
+                menu_items.push({
+                    html: i18n('set_as_desktop_background'),
+                    onClick: async function () {
+                        try {
+                            // Sign the file to get a read_url (signed URL with authentication)
+                            const signed_file = await puter.fs.sign(undefined, {uid: options.uid, action: 'read'});
+                            const file_data = signed_file.items || signed_file;
+
+                            if (!file_data || !file_data.read_url) {
+                                throw new Error('Could not get file URL');
+                            }
+
+                            // Set the desktop background immediately using the signed read_url
+                            window.set_desktop_background({
+                                url: file_data.read_url,
+                                fit: 'cover'
+                            });
+
+                            // Save to backend
+                            $.ajax({
+                                url: window.api_origin + "/set-desktop-bg",
+                                type: 'POST',
+                                data: JSON.stringify({
+                                    url: window.desktop_bg_url,
+                                    color: window.desktop_bg_color,
+                                    fit: window.desktop_bg_fit,
+                                }),
+                                async: true,
+                                contentType: "application/json",
+                                headers: {
+                                    "Authorization": "Bearer " + window.auth_token
+                                },
+                                statusCode: {
+                                    401: function () { window.logout(); }
+                                },
+                            });
+                        } catch (error) {
+                            console.error('Failed to set desktop background:', error);
+                            UIAlert({
+                                message: 'Failed to set desktop background. Please try again.',
+                            });
+                        }
+                    }
+                });
             }
 
             // -------------------------------------------

--- a/src/gui/src/i18n/translations/en.js
+++ b/src/gui/src/i18n/translations/en.js
@@ -266,6 +266,7 @@ const en = {
         send: "Send",
         send_password_recovery_email: "Send Password Recovery Email",
         session_saved: "Thank you for creating an account. This session has been saved.",
+        set_as_desktop_background: "Set as Desktop Background",
         settings: "Settings",
         set_new_password: "Set New Password",
         share: "Share",


### PR DESCRIPTION
## Summary
Add "Set as Desktop Background" context menu item to image files, allowing users to quickly set any image as their desktop wallpaper by right-clicking on it.

## Related Issue
- [x] **Closes** #19 

## Type of Change
- [ ] 🐛 **fix:** Bug fixes
- [x] ✨ **feat:** New features (first introduction of a feature)
- [ ] 🔧 **dev:** Refactoring, improvements, or other development changes
- [ ] 🔄 **tweak:** Small updates or adjustments
- [ ] 📚 **docs:** Documentation only changes
- [ ] 🔄 **sync:** Updates from another source
- [ ] 🎨 Style changes (formatting, no functional changes)
- [ ] ✅ Tests (adding or updating tests)
- [ ] 🔧 Build/CI changes

## Changes Made
- Add "Set as Desktop Background" menu item to context menu for image files
- Add i18n translation string for the new menu option
- Implement file signing to generate authenticated URLs for background images
- Integrate with existing desktop background settings system
- Add MIME type detection to ensure menu only appears for image files
- Exclude menu item from trash and trashed items
- Add error handling with user-friendly alert messages

## Testing
- [x] I have tested this change locally
- [x] I have verified no regressions in "appspace" (Puter apps)
- [x] I have tested on multiple browsers (if UI changes)
- [x] All existing functionality still works as expected

**Testing Details:**
- Tested right-clicking on various image formats (PNG, JPG, GIF)
- Verified menu item only appears for image files, not folders or non-image files
- Verified menu item does not appear in trash or for trashed items
- Confirmed background changes immediately when menu item is clicked
- Verified background persists across page refreshes
- Tested that existing "Change Desktop Background" settings dialog still works correctly
- Confirmed no console errors or warnings during operation

## Screenshots/Demo

Reproduced:

https://github.com/user-attachments/assets/501eef8e-2314-4d5b-8871-0698723e18d3



Result:

https://github.com/user-attachments/assets/fbed65aa-355a-486f-afe2-e0b0c8efc9c4


## Code Quality Checklist
- [x] I have avoided unnecessary whitespace changes
- [x] I have followed the project-level conventions for the area I'm working in:
  - [ ] FOAM whitespace convention for `src/backend` (if applicable)
  - [x] Standard whitespace for `src/gui` (if applicable)
- [x] I have kept formatting changes separate from functional changes
- [x] I have used imperative mood in commit messages
- [x] My changes generate no new warnings or errors

## Puter-Specific Checks
- [x] **No regressions for "appspace"** - Existing Puter apps still work correctly
- [x] If this changes APIs, I have considered backward compatibility
- [x] If this affects the file system, I have tested file operations
- [ ] If this affects user authentication, I have tested sign-in/sign-up flows

## Additional Context
**Implementation Details:**
- Uses `puter.fs.sign()` to generate signed URLs with authentication tokens, ensuring secure access to user files
- Integrates seamlessly with the existing `window.set_desktop_background()` function and `/set-desktop-bg` backend endpoint
- The menu item is positioned logically in the context menu, appearing after "Deploy As App" for image files
- Error handling includes both console logging for debugging and user-facing alerts for better UX

**Technical Notes:**
- When signing a single file, `puter.fs.sign()` returns `{token: ..., items: {...}}` where `items` is an object (not an array)
- The signed URL includes authentication tokens that allow the browser to access the file without additional authorization headers in the CSS background-image property
- Background fit defaults to 'cover' for optimal appearance across different image aspect ratios

**Future Enhancements:**
- Could add a submenu to select different fit options (cover, contain, center, repeat) directly from the context menu
- Could add "Set as Lock Screen" option for dual wallpaper support