### PR TITLE
Closes Issue #9 - fix: resolve const reassignment error in social media image validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -944,6 +944,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2312,6 +2313,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.22.12.tgz",
       "integrity": "sha512-xcmww1O/JFP2MrlGUMd3Q78S3Qu6W3mYTXYuIqFq33EorgYHV/HqymHfXy9GjiCJ7OI+7lWx6nYFOzU7M4rd1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/core": "^0.22.12"
       }
@@ -2348,6 +2350,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.22.12.tgz",
       "integrity": "sha512-xslz2ZoFZOPLY8EZ4dC29m168BtDx95D6K80TzgUi8gqT7LY6CsajWO0FAxDwHz6h0eomHMfyGX0stspBrTKnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -2360,6 +2363,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.22.12.tgz",
       "integrity": "sha512-S0vJADTuh1Q9F+cXAwFPlrKWzDj2F9t/9JAbUvaaDuivpyWuImEKXVz5PUZw2NbpuSHjwssbTpOZ8F13iJX4uw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -2384,6 +2388,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.22.12.tgz",
       "integrity": "sha512-xImhTE5BpS8xa+mAN6j4sMRWaUgUDLoaGHhJhpC+r7SKKErYDR0WQV4yCE4gP+N0gozD0F3Ka1LUSaMXrn7ZIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12",
         "tinycolor2": "^1.6.0"
@@ -2427,6 +2432,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.22.12.tgz",
       "integrity": "sha512-FNuUN0OVzRCozx8XSgP9MyLGMxNHHJMFt+LJuFjn1mu3k0VQxrzqbN06yIl46TVejhyAhcq5gLzqmSCHvlcBVw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -2550,6 +2556,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.22.12.tgz",
       "integrity": "sha512-3NyTPlPbTnGKDIbaBgQ3HbE6wXbAlFfxHVERmrbqAi8R3r6fQPxpCauA8UVDnieg5eo04D0T8nnnNIX//i/sXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -2562,6 +2569,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.22.12.tgz",
       "integrity": "sha512-9YNEt7BPAFfTls2FGfKBVgwwLUuKqy+E8bDGGEsOqHtbuhbshVGxN2WMZaD4gh5IDWvR+emmmPPWGgaYNYt1gA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -2577,6 +2585,7 @@
       "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.22.12.tgz",
       "integrity": "sha512-dghs92qM6MhHj0HrV2qAwKPMklQtjNpoYgAB94ysYpsXslhRTiPisueSIELRwZGEr0J0VUxpUY7HgJwlSIgGZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jimp/utils": "^0.22.12"
       },
@@ -2847,6 +2856,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2856,6 +2866,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
       "integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -6400,7 +6411,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -6450,6 +6462,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7260,6 +7273,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -7501,6 +7515,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -9182,6 +9197,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -14469,6 +14485,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15907,6 +15924,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16193,6 +16211,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
       "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -16242,6 +16261,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -16464,6 +16484,7 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
       "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
@@ -16659,6 +16680,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -16994,6 +17016,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/backend/src/services/PuterHomepageService.js
+++ b/src/backend/src/services/PuterHomepageService.js
@@ -192,18 +192,21 @@ class PuterHomepageService extends BaseService {
 
         const bundled = env != 'dev' || use_bundled_gui;
 
+        // Validate social media image URL and fall back to default if invalid
+        let validated_social_media_image = social_media_image;
+
         // if social media image is not a valid absolute URL, set it to null
-        if (social_media_image && !is_valid_url(social_media_image)) {
-            social_media_image = null;
+        if (validated_social_media_image && !is_valid_url(validated_social_media_image)) {
+            validated_social_media_image = null;
         }
 
         // social media image must end with a valid image extension
-        if (social_media_image && !/\.(png|jpg|jpeg|gif|webp)$/.test(social_media_image.toLowerCase())) {
-            social_media_image = null;
+        if (validated_social_media_image && !/\.(png|jpg|jpeg|gif|webp)$/i.test(validated_social_media_image)) {
+            validated_social_media_image = null;
         }
 
         // set social media image to default if it is not valid
-        const social_media_image_url = social_media_image || `${asset_dir}/images/screenshot.png`;
+        const social_media_image_url = validated_social_media_image || `${asset_dir}/images/screenshot.png`;
 
         // Custom script tags to be added to the homepage by extensions
         // an event is emitted to allow extensions to add their own script tags


### PR DESCRIPTION
## Summary
Fixed a runtime error in `PuterHomepageService.js` where the code attempted to reassign a `const` variable when validating social media image URLs. This caused a `TypeError: Assignment to constant variable` when an invalid URL was configured.

## Related Issue
- [x] **Fixes** #32 

## Type of Change
- [x] 🐛 **fix:** Bug fixes

## Changes Made
- Introduced a new `let` variable (`validated_social_media_image`) to hold the mutable validation state instead of reassigning the `const` variable
- Changed regex to use case-insensitive flag (`/i`) for cleaner image extension checking

## Testing
- [x] I have tested this change locally
- [x] All existing functionality still works as expected

**Testing Details:**
- Tested with valid URL and valid image extension (e.g., `https://example.com/image.png`) - uses the provided URL
- Tested with invalid URL format (e.g., `not-a-valid-url`) - falls back to default image
- Tested with valid URL but invalid extension (e.g., `https://example.com/file.txt`) - falls back to default image
- Tested with no social media image configured - falls back to default image
- Verified no more `TypeError: Assignment to constant variable` errors

## Testing Fix Steps
- Open your browser to: http://puter.localhost:4100/
 - The page should load successfully (no errors) - this proves the fix works!
- View page source (right-click → View Page Source) and look for:
- og:image should show /src/images/screenshot.png (the fallback)
- twitter:image should show /src/images/screenshot.png (the fallback)
- Check the terminal - there should be NO TypeError: Assignment to constant variable error

The config has "social_media_image": "not-a-valid-url" which would have crashed before the fix, but now it gracefully falls back to the default image.

## Screenshots/Demo
Reproduced

https://github.com/user-attachments/assets/664e6f6c-f1fa-4639-a938-52e4aa63a8c1

Fix
<img width="1530" height="1011" alt="image" src="https://github.com/user-attachments/assets/21ede69d-09e8-4bc5-b983-d947f19c3cc2" />

## Code Quality Checklist
- [x] I have avoided unnecessary whitespace changes
- [x] I have followed the project-level conventions for the area I'm working in:
  - [x] FOAM whitespace convention for `src/backend` (if applicable)
- [x] I have kept formatting changes separate from functional changes
- [x] I have used imperative mood in commit messages
- [x] My changes generate no new warnings or errors

## Puter-Specific Checks
- [x] **No regressions for "appspace"** - Existing Puter apps still work correctly
- [x] If this changes APIs, I have considered backward compatibility

## Additional Context
The bug occurred because `social_media_image` was destructured from the `meta` object as a `const`, but the validation logic attempted to set it to `null` when validation failed. JavaScript `const` variables cannot be reassigned after declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)